### PR TITLE
Fix connections and unify node style

### DIFF
--- a/src/components/CustomNode.jsx
+++ b/src/components/CustomNode.jsx
@@ -20,12 +20,16 @@ const CustomNode = React.memo(({ data, id, selected }) => {
     return Math.max(baseHeight, estimatedLines * lineHeight + 40); // 40px for padding
   }, [label]);
 
-  const currentLevel = data.level || 4;
-  const levelInfo = data.hierarchyLevels?.[currentLevel] || {
+  const defaultLevel = {
     name: 'Individual',
     color: '#96ceb4',
     bgColor: '#f0fff4'
   };
+
+  const currentLevel = data.level || 4;
+  const levelInfo = data.showHierarchy
+    ? data.hierarchyLevels?.[currentLevel] || defaultLevel
+    : defaultLevel;
   // 8 compass positions mapped to ReactFlow's Handle positions
   const handlePositions = [
     { pos: Position.Top, id: 'n', style: { left: '50%', top: -6, transform: 'translateX(-50%)' } },

--- a/src/components/IdeaCanvas.jsx
+++ b/src/components/IdeaCanvas.jsx
@@ -269,19 +269,9 @@ const IdeaCanvas = () => {
   }, []);
 
   const isValidConnection = useCallback((connection) => {
-    // Prevent self-connections
-    if (connection.source === connection.target) {
-      return false;
-    }
-    
-    // Check for existing connections
-    const existingEdge = edges.find(edge => 
-      edge.source === connection.source && 
-      edge.target === connection.target
-    );
-    
-    return !existingEdge;
-  }, [edges]);
+    // Only prevent self connections. Allow multiple edges between nodes.
+    return connection.source !== connection.target;
+  }, []);
 
   const onConnect = useCallback((params) => {
     const newEdge = {


### PR DESCRIPTION
## Summary
- simplify edge validation so users can link nodes without the arrow disappearing
- use a default color scheme whenever hierarchy levels are hidden

## Testing
- `npm test --silent` *(fails: Cannot read properties of null (reading 'document'))*

------
https://chatgpt.com/codex/tasks/task_e_6866b4813d048321b06d16c36247167f